### PR TITLE
Add mfa device selection

### DIFF
--- a/aws_cli_mfa/main.py
+++ b/aws_cli_mfa/main.py
@@ -86,7 +86,7 @@ def main(
     ),
     mfa_device_to_use: str = typer.Option(
         None, 
-        "-m", "--mfa-device", help="The name of the mfa device to use"
+        "-m", "--mfa-device", help="The name of the mfa device to use. By default, the latest configured MFA device is used"
     )
 ):
     if not (one_time_password or op_item_or_uuid):


### PR DESCRIPTION
Hey @bsamseth :)
Hope you're well! Yes, I still use your script :) It's simple and gets the job done and works smoothly with the profile setup.

This PR adds a way to select an MFA device to use and by default picks the latest mfa device added by calling [list_mfa_devices](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/iam/client/list_mfa_devices.html). Seems like AWS changed the mfa setup sometime in the past and now every mfa device needs to be named by the user. I don't remember entering a 'name' for the virtual mfa device when I first set it up.